### PR TITLE
SIVA-1096 Support file: path for siva.service.trust-store configuration

### DIFF
--- a/src/main/java/ee/openeid/siva/demo/configuration/SivaDemoConfiguration.java
+++ b/src/main/java/ee/openeid/siva/demo/configuration/SivaDemoConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
@@ -64,7 +63,7 @@ public class SivaDemoConfiguration {
     private RestTemplateBuilder getBaseSslRestTemplateBuilder(RestTemplateBuilder restTemplateBuilder) {
         SSLContext sslContext = new SSLContextBuilder()
                 .loadTrustMaterial(
-                        new ClassPathResource(proxyProperties.getTrustStore()).getURL(),
+                        proxyProperties.getTrustStore().getURL(),
                         proxyProperties.getTrustStorePassword().toCharArray())
                 .build();
         SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext,

--- a/src/main/java/ee/openeid/siva/demo/configuration/SivaServiceProperties.java
+++ b/src/main/java/ee/openeid/siva/demo/configuration/SivaServiceProperties.java
@@ -18,6 +18,8 @@ package ee.openeid.siva.demo.configuration;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 @Data
 @ConfigurationProperties(prefix = "siva.service")
@@ -27,7 +29,7 @@ public class SivaServiceProperties {
     private String hashcodeServicePath = "/validateHashcode";
     private String dataFilesServicePath = "/getDataFiles";
     private String serviceHost = DEFAULT_SERVICE_URL;
-    private String trustStore = "siva_server_truststore.p12";
+    private Resource trustStore = new ClassPathResource("siva_server_truststore.p12");
     @SuppressWarnings("squid:S2068") //default password
     private String trustStorePassword = "password";
 }

--- a/src/test/java/ee/openeid/siva/demo/configuration/SivaDemoConfigurationTest.java
+++ b/src/test/java/ee/openeid/siva/demo/configuration/SivaDemoConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 - 2026 Riigi Infosüsteemi Amet
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+
+package ee.openeid.siva.demo.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.UrlResource;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class SivaDemoConfigurationTest {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Test
+    void restTemplateBeanInitializesWithDefaultClasspathTruststore() {
+        assertNotNull(restTemplate);
+    }
+
+    @Test
+    void restTemplateBeanInitializesWithFilePrefixTruststore(@TempDir Path tempDir) throws Exception {
+        Path truststorePath = tempDir.resolve("truststore.p12");
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("siva_server_truststore.p12")) {
+            assertNotNull(is, "siva_server_truststore.p12 not found on test classpath");
+            Files.copy(is, truststorePath);
+        }
+
+        SivaServiceProperties props = new SivaServiceProperties();
+        props.setTrustStore(new UrlResource("file:" + truststorePath.toAbsolutePath()));
+        props.setTrustStorePassword("password");
+
+        RestTemplate result = new SivaDemoConfiguration(props).restTemplate(new RestTemplateBuilder());
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
Adds support for file: path for siva.service.trust-store configuration, allowing truststore to be loaded from file outside of classpath. 